### PR TITLE
adding camp:// URI

### DIFF
--- a/pkg/mesh/mesh_campfire.go
+++ b/pkg/mesh/mesh_campfire.go
@@ -32,7 +32,7 @@ import (
 
 func (s *meshStore) waitByCampfire() {
 	log := s.log.With("protocol", "campfire")
-	ourcamp := campfire.Campfire{PSK: []byte(s.opts.Mesh.WaitCampfirePSK),
+	ourcamp := campfire.CampfireURI{PSK: []byte(s.opts.Mesh.WaitCampfirePSK),
 		TURNServers: s.opts.Mesh.WaitCampfireTURNServers}
 	cf, err := campfire.Wait(context.Background(), &ourcamp)
 	if err != nil {


### PR DESCRIPTION
It parses a camp uri similar to -camp 'camp://9d4e8faba9a93ef397554dc4:hLxK4U49l6fcZLH0@a.relay.metered.ca/?fingerprint#abcdefghijklmnopqrstuvwx12345678' and makes a connection to the supplied TURN server.